### PR TITLE
WIP: Add support for consul config

### DIFF
--- a/scripts/consul2files.sh
+++ b/scripts/consul2files.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# CONSUL2FILESTREE
+#
+# Utility to use with command 'consul watch'
+#
+# Monitors a tree of keys in Consul and write them
+# to a local path as configuration tree of files
+#
+
+
+KV_PREFIX=$1
+DEST_PREFIX=${2:-/var/www/html/settings}
+DEST_UID=${3:-$UID}
+
+
+# a simple log function in bash
+# usage:
+#   log "my info message"
+#   log "my debug message" debug
+
+log_level=info
+# uncomment next line to rise up log level
+log_level=debug
+
+log() {
+   local msg=$1
+   local level=${2:-info}
+   if [[ $level == debug ]] && [[ $log_level != debug ]]; then
+          return 0
+   fi
+   now=$(date --rfc-3339=seconds)
+   echo "$now [$level] $msg" >> /dev/stderr
+}
+
+
+# check input parameters
+if [[ $KV_PREFIX == '' ]]; then
+  log "Missing arg #1 KV_PREFIX"
+  exit 1
+fi
+
+# Check to see if a pipe exists on stdin.
+# if not the script is not executed by consul watch command
+if [ ! -p /dev/stdin ]; then
+  log "No input was found on stdin, skipping! Script must be run from consul watch..."
+  exit 2
+fi
+
+# on first execution cleanup the $DEST_PREFIX path
+if [[ ! -f $DEST_PREFIX/.first_run ]]; then
+  log "First time running, cleaning $DEST_PREFIX" debug
+  rm -rf $DEST_PREFIX/*
+  touch $DEST_PREFIX/.first_run
+fi
+
+
+
+# get the list of files changed
+files=$(cat - | jq -r '.[].Key' |grep -v '/$')
+
+# write each file in the list
+# (ignoring if it's updated or not)
+for file in $files; do
+  content=$(consul kv get $file)
+  # remove the prefix from the path: the relative path in consul is the relative path in filesystem
+  relative_path=${file#*$KV_PREFIX/}
+
+  # choose the final path in the filesystem
+  final_pathname="$DEST_PREFIX/$relative_path"
+  
+  log "$file -> $final_pathname" debug
+  
+  # check if all the parent directories exists, or create them if needed
+  final_path=$(dirname $final_pathname)
+  if [[ ! -d $final_path ]]; then
+    log "Creating missing directory '$final_path'" debug
+    mkdir --parents $final_path
+    # chown $DEST_UID:$DEST_GID $final_path
+  fi
+
+  echo $content > $final_pathname
+
+  if [[ ! -f $final_pathname ]]; then
+    log "Error, creating file '$final_pathname'"
+  else
+    # sudo chown $DEST_UID:$DEST_GID $final_pathname
+    log "Wrote '$final_pathname'"
+  fi
+done

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -120,5 +120,8 @@ for logfile in cluster_error debug error ocfoshttpcache storage warning mugo_var
   [[ -f $logfile ]] && tail -F --pid $$ /var/www/html/var/log/${logfile}.log &
 done
 
+if [[ -n $CONSUL_PREFIX ]]; then
+  consul watch -type=keyprefix -prefix=${CONSUL_PREFIX} /scripts/consul2files.sh ${CONSUL_PREFIX} /var/www/html/settings 
+fi
 
 exec "$@"

--- a/scripts/files2consul.sh
+++ b/scripts/files2consul.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# FILES2CONSUL
+#
+# Import a directory and subdirectories to consul
+# creating a key for each file containing the content 
+# of the file as its value
+
+### COMMODITY FUNCTIONS
+
+# a simple log function in bash
+# usage:
+#   log "my info message"
+#   log "my debug message" debug
+log() {
+   local msg=$1
+   local level=${2:-info}
+   if [[ $level == debug ]] && [[ $log_level != debug ]]; then
+          return 0
+   fi
+   now=$(date --rfc-3339=seconds)
+   echo "$now [$level] $msg" >> /dev/stderr
+}
+
+show_syntax() 
+{
+  cat <<HERE
+
+  FILES2CONSUL
+ 
+  Import a directory and subdirectories to consul
+  creating a key for each file containing the content 
+  of the file as its value
+ 
+  Syntax:
+ 
+   files2consul -k <PREFIX> [-p PATH] [-v] 
+ 
+    -k PREFIX: 	prefix keys in Consul
+    -p PATH:    local path to search for files (default: .)
+    -v: 	verbose
+    -y:		don't ask for confirmation (unattended run)
+
+HERE
+}
+
+error() {
+  msg=$1
+  echo 
+  log "$msg" error
+  show_syntax
+  exit 1
+}
+
+### ARGUMENT PARSING
+
+log_level=info
+consul_prefix=''
+local_path='.'
+unattended=false
+while getopts 'abf:v' flag; do
+  case "${flag}" in
+    k) consul_prefix="${OPTARG}" ;;
+    p) local_path="${OPTARG}" ;;
+    v) log_level='debug' ;;
+    y) unattended=true ;;
+    *) error "Unexpected option ${flag}" ;;
+  esac
+done
+
+[[ $consul_prefix == '' ]] && error "Missing argument 'consul prefix'"
+
+
+### MAIN SCRIPT
+
+files_list=$(find $local_path -type f)
+files_count=$(echo $files | wc -w)
+
+if [[ $unattended == false ]]; then
+  echo "Importing ${files_count} files to Consul under path ${consul_prefix}"
+  echo "Press any key to continue, CTRL+C to stop here..."
+  read nothing
+fi
+
+for file in $files_list; do
+  relative_path=${file#*${local_path}/}
+  dest_key="${consul_prefix}/${relative_path}"
+  consul kv put $dest_key @${file}
+  log "Loaded $file in $dest_key"
+done
+
+log "Finished successfully." debug


### PR DESCRIPTION
Two utilities added: 
- files2consul.sh, to load a set of configuration files to a consul KV store under a $CONSUL_PREFIX key
- consul2files.sh, to create a set of configuration files from a tree of keys stored in consul KV under the $CONSUL_PREFIX key

docker-entrypoint activate a consul watch command if the $CONSUL_PREFIX variable is set to a valid value
