### PR TITLE
Fixed error in spid authentication when nginx is behind Sirac

### DIFF
--- a/conf.d/nginx.conf
+++ b/conf.d/nginx.conf
@@ -28,5 +28,9 @@ http {
 
     #gzip  on;
 
+    # required by ocsirac extension: we receive headers like COMGE_USERNAME
+    # from SPID authentication middlewares
+    underscores_in_headers on;
+
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
we need to manage headers with prefix like comege_username